### PR TITLE
Fix vis_pose_result import error

### DIFF
--- a/mmpose/apis/__init__.py
+++ b/mmpose/apis/__init__.py
@@ -5,12 +5,13 @@ from .inference_3d import (collate_pose_sequence, convert_keypoint_definition,
                            extract_pose_sequence, inference_pose_lifter_model)
 from .inference_tracking import _compute_iou, _track_by_iou, _track_by_oks
 from .inferencers import MMPoseInferencer, Pose2DInferencer
-from .visualization import visualize
+from .visualization import visualize, vis_pose_result
 
 __all__ = [
     'init_model', 'inference_topdown', 'inference_bottomup',
     'collect_multi_frames', 'Pose2DInferencer', 'MMPoseInferencer',
     '_track_by_iou', '_track_by_oks', '_compute_iou',
     'inference_pose_lifter_model', 'extract_pose_sequence',
-    'convert_keypoint_definition', 'collate_pose_sequence', 'visualize'
+    'convert_keypoint_definition', 'collate_pose_sequence', 'visualize',
+    'vis_pose_result'
 ]

--- a/mmpose/apis/inference.py
+++ b/mmpose/apis/inference.py
@@ -261,3 +261,42 @@ def collect_multi_frames(video, frame_id, indices, online=False):
         frames.append(video[support_idx])
 
     return frames
+
+
+def init_pose_model(config: Union[str, Path, Config],
+                    checkpoint: Optional[str] = None,
+                    device: str = 'cuda:0',
+                    cfg_options: Optional[dict] = None) -> nn.Module:
+    """Compatibility wrapper for the deprecated ``init_pose_model`` API."""
+    warnings.warn(
+        '``init_pose_model`` is deprecated. Please use ``init_model``',
+        DeprecationWarning)
+    return init_model(config, checkpoint, device=device,
+                      cfg_options=cfg_options)
+
+
+def inference_top_down_pose_model(model: nn.Module,
+                                   img: Union[np.ndarray, str],
+                                   person_results: Optional[List[dict]] = None,
+                                   bbox_thr: Optional[float] = None,
+                                   format: str = 'xyxy',
+                                   dataset: Optional[str] = None,
+                                   return_heatmap: bool = False,
+                                   outputs: Optional[List[str]] = None):
+    """Compatibility wrapper for the deprecated
+    ``inference_top_down_pose_model`` API."""
+    warnings.warn(
+        '``inference_top_down_pose_model`` is deprecated. '
+        'Please use ``inference_topdown``',
+        DeprecationWarning)
+
+    if person_results is not None:
+        bboxes = np.array([res['bbox'] for res in person_results])
+    else:
+        bboxes = None
+
+    results = inference_topdown(model, img, bboxes, bbox_format=format)
+
+    # The legacy API returns a tuple ``(results, None)`` where the second
+    # element is reserved for network outputs.
+    return results, None

--- a/mmpose/apis/visualization.py
+++ b/mmpose/apis/visualization.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from copy import deepcopy
-from typing import Union
+from typing import List, Union
 
 import mmcv
 import numpy as np
@@ -80,3 +80,56 @@ def visualize(
         kpt_thr=kpt_thr)
 
     return visualizer.get_image()
+
+
+def vis_pose_result(
+    model,
+    img: Union[np.ndarray, str],
+    result: List[PoseDataSample],
+    radius: int = 4,
+    thickness: int = 1,
+    kpt_score_thr: float = 0.3,
+    show: bool = False,
+    draw_heatmap: bool = False,
+    alpha: float = 1.0,
+    skeleton_style: str = 'mmpose',
+) -> np.ndarray:
+    """A compatibility wrapper of the deprecated ``vis_pose_result`` API.
+
+    Args:
+        model: The pose estimator model. Only ``model.dataset_meta`` is used.
+        img (str | np.ndarray): Image file or array to draw.
+        result (list[PoseDataSample]): Inference results from
+            :func:`inference_topdown`.
+        radius (int): Keypoint radius. Defaults to 4.
+        thickness (int): Link thickness. Defaults to 1.
+        kpt_score_thr (float): Threshold of keypoint scores. Defaults to 0.3.
+        show (bool): Whether to show the image. Defaults to False.
+        draw_heatmap (bool): Unused. For compatibility only.
+        alpha (float): Transparency of the drawn results. Defaults to 1.0.
+        skeleton_style (str): Skeleton style. Defaults to ``'mmpose'``.
+
+    Returns:
+        np.ndarray: The visualized image in ``RGB`` format.
+    """
+
+    if not isinstance(result, list):
+        result = [result]
+
+    keypoints = np.stack([r.pred_instances.keypoints[0] for r in result])
+    scores = np.stack([r.pred_instances.keypoint_scores[0] for r in result])
+
+    visualizer = PoseLocalVisualizer(
+        radius=radius, line_width=thickness, alpha=alpha)
+
+    return visualize(
+        img,
+        keypoints,
+        scores,
+        metainfo=getattr(model, 'dataset_meta', None),
+        visualizer=visualizer,
+        show_kpt_idx=False,
+        skeleton_style=skeleton_style,
+        show=show,
+        kpt_thr=kpt_score_thr,
+    )


### PR DESCRIPTION
## Summary
- export vis_pose_result in mmpose.apis
- add compatibility wrappers for legacy APIs
- implement vis_pose_result wrapper to visualize PoseDataSamples

## Testing
- `pytest -c /dev/null -p no:xdoctest --maxfail=1 -k vis_pose_result -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ab5461f64832084afb3ba4bddcd99