### PR TITLE
Fix inference call for YOLO pose demo

### DIFF
--- a/run_yolo_mmpose.py
+++ b/run_yolo_mmpose.py
@@ -36,7 +36,7 @@ pose_results = inference_topdown(
     pose_model,
     IMG_PATH,
     person_results,
-    format='xyxy',
+    bbox_format='xyxy',
     dataset='TopDownCocoDataset'
 )
 


### PR DESCRIPTION
## Summary
- fix the `inference_topdown` invocation to use `bbox_format`

## Testing
- `pytest -q` *(fails: unrecognized arguments `--xdoctest --xdoctest-style=auto`)*

------
https://chatgpt.com/codex/tasks/task_e_684abc94eb948320848279380f33b076